### PR TITLE
Extract GQL scalar mappings from discounts. Add Decimal type.

### DIFF
--- a/myfunc/input.graphql
+++ b/myfunc/input.graphql
@@ -2,6 +2,11 @@ query InputQuery {
   cart {
     lines {
       quantity
+      cost {
+        totalAmount {
+          amount
+        }
+      }
       merchandise {
         __typename
         ...on ProductVariant {

--- a/myfunc/src/main.rs
+++ b/myfunc/src/main.rs
@@ -1,5 +1,7 @@
 use shopify_function::{
-    discounts, input_query,
+    discounts,
+    scalars::*,
+    input_query,
     serde::{Deserialize, Serialize},
     serde_json, shopify_function, Result,
 };

--- a/shopify_function/src/discounts.rs
+++ b/shopify_function/src/discounts.rs
@@ -1,12 +1,9 @@
 #![allow(dead_code)]
 
-pub type Boolean = bool;
-pub type Float = f64;
-pub type Int = i64;
-pub type ID = String;
-
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+
+use super::scalars::*;
 
 #[derive(Clone, Debug, Serialize, PartialEq, Deserialize)]
 #[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]

--- a/shopify_function/src/lib.rs
+++ b/shopify_function/src/lib.rs
@@ -3,6 +3,7 @@ pub use serde_json;
 pub use shopify_function_macro::{input_query, shopify_function};
 
 pub mod discounts;
+pub mod scalars;
 
 pub type Result<T> = anyhow::Result<T>;
 

--- a/shopify_function/src/scalars.rs
+++ b/shopify_function/src/scalars.rs
@@ -1,0 +1,5 @@
+pub type Boolean = bool;
+pub type Float = f64;
+pub type Int = i64;
+pub type ID = String;
+pub type Decimal = String;


### PR DESCRIPTION
If an input query requests a field that eventually needs the Decimal scalar, the Function build will fail when running the `input_query` macro. This is due to lacking a mapping for Decimal.

This PR adds a Decimal type (mapping it to String).

While I was figuring that out, I realized that the scalar types were inside the discounts module. My function isn't using discounts, so I extracted the scalars as a separate module for use with my extension (return promise).