### PR TITLE
Add debug derive for response

### DIFF
--- a/shopify_function_macro/src/lib.rs
+++ b/shopify_function_macro/src/lib.rs
@@ -48,7 +48,7 @@ pub fn input_query(
     return quote! {
         #[derive(graphql_client::GraphQLQuery, Clone, Debug, serde::Deserialize, PartialEq)]
         #[serde(rename_all(deserialize = "camelCase"))]
-        #[graphql(#params)]
+        #[graphql(#params, response_derives = "Debug",)]
         struct InputQuery;
 
         #ast


### PR DESCRIPTION
ResponseData struct from the GraphQL library doesn't have Debug by default. Adding `response_derives` to the macro [allows specifying derives for the response struct](https://github.com/graphql-rust/graphql-client#getting-started).

<img width="854" alt="Screen Shot 2022-09-27 at 3 28 24 PM" src="https://user-images.githubusercontent.com/475851/192618063-2dc246fe-6555-41e4-81f4-1e64d08fea7f.png">
