### PR TITLE
Add function output assertion macro

### DIFF
--- a/shopify_function/src/lib.rs
+++ b/shopify_function/src/lib.rs
@@ -37,5 +37,17 @@ where
     f(parsed_payload)
 }
 
+#[macro_export]
+macro_rules! assert_function_output {
+  ($function_input:expr, $expected:expr) => {{
+      let output = run_function_with_input(crate::function, $function_input);
+      assert!(output.is_ok());
+      assert_eq!(
+          output.unwrap(),
+          $expected
+      );
+  }};
+}
+
 #[cfg(test)]
 mod tests {}


### PR DESCRIPTION
Extract function output test assertion from https://github.com/Shopify/return-promise-builder/pull/9 for general use.

It's in the `shopify_function` crate as `proc_macro` crates can't export `macro_rules!` macros.