### PR TITLE
Input query must be named Input

### DIFF
--- a/shopify_function_macro/src/lib.rs
+++ b/shopify_function_macro/src/lib.rs
@@ -81,7 +81,7 @@ const OUTPUT_QUERY_FILE_NAME: &str = ".output.graphql";
 ///
 /// The macro takes two parameters:
 /// - `query_path`: A path to a GraphQL query, whose result will be used
-///    as the input for the function invocation. The query MUST be named "input".
+///    as the input for the function invocation. The query MUST be named "Input".
 /// - `schema_path`: A path to Shopify's GraphQL schema definition. You
 ///   can find it in the `example` folder of the repo, or use the CLI
 ///   to download a fresh copy (not implemented yet).


### PR DESCRIPTION
I read the comment and was suspicious that "input" (lowercase) would work as the query name. Error:

```
shopifyvm        | Building function shopifyvm...
 shopifyvm        |    Compiling shopifyvm v1.0.0 (/Users/d/apps/delta-pham/extensions/shopifyvm)
 shopifyvm        |
 shopifyvm        | error: Failed to generate GraphQLQuery impl: The struct name does not match any defined operation in the query
                    file.
 shopifyvm        |        Struct name: Input
 shopifyvm        |        Defined operations: input
 shopifyvm        |   --> src/main.rs:8:1
 shopifyvm        |    |
 shopifyvm        | 8  | / generate_types!(
 shopifyvm        | 9  | |     query_path = "./input.graphql",
 shopifyvm        | 10 | |     schema_path = "./schema.graphql"
 shopifyvm        | 11 | | );
 shopifyvm        |    | |_^
 shopifyvm        |    |
 shopifyvm        |    = note: this error originates in the macro `generate_types` (in Nightly builds, run with -Z macro-backtrace for
                    more info)
 shopifyvm        |
 shopifyvm        |
 shopifyvm        | error[E0433]: failed to resolve: use of undeclared crate or module `input`
 shopifyvm        |   --> src/main.rs:17:20
```