### PR TITLE
Add URL type

### DIFF
--- a/shopify_function/src/scalars.rs
+++ b/shopify_function/src/scalars.rs
@@ -4,3 +4,4 @@ pub type Int = i64;
 pub type ID = String;
 pub type Decimal = String;
 pub type Void = ();
+pub type URL = String;


### PR DESCRIPTION
The URL type is used in the Cart Transform API.