### PR TITLE
Fix shopify_function macro return type (fixes #23)

### DIFF
--- a/shopify_function_macro/src/lib.rs
+++ b/shopify_function_macro/src/lib.rs
@@ -42,7 +42,7 @@ pub fn shopify_function(
     };
 
     let gen = quote! {
-        fn main() -> Result<()> {
+        fn main() -> ::shopify_function::Result<()> {
             let input: #input_type = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
             let mut out = std::io::stdout();
             let mut serializer = serde_json::Serializer::new(&mut out);


### PR DESCRIPTION
This makes sure the function generated by the `shopify_function` macro uses the correct `Result` type, no matter if it has been imported or not. Fixes #23.