### PR TITLE
Write to a buf before writing to stdout

### DIFF
--- a/shopify_function_macro/src/lib.rs
+++ b/shopify_function_macro/src/lib.rs
@@ -104,8 +104,9 @@ pub fn shopify_function(
             std::io::Read::read_to_string(&mut #input_stream, &mut string)?;
             let input: #input_type = serde_json::from_str(&string)?;
             let mut out = #output_stream;
-            let mut serializer = serde_json::Serializer::new(&mut out);
-            #name(input)?.serialize(&mut serializer)?;
+            let result = #name(input)?;
+            let serialized = serde_json::to_vec(&result)?;
+            std::io::Write::write_all(&mut out, serialized.as_slice())?;
             Ok(())
         }
         #ast


### PR DESCRIPTION
I noticed that using serde to write to stdout consumes quite a bit of fuel. Not sure why.

Here's a result from a test I ran (not using the Functions crate, but doing essentially the same thing):

  Before:

  ```
  Linear Memory Usage: 1216KB
  Instructions: 9.243096M
  Size: 180KB
  ```

  After:

  ```
  Linear Memory Usage: 1280KB
  Instructions: 6.448534M
  Size: 181KB
  ```