### PR TITLE
Refactor generate types

### DIFF
--- a/example/.output.graphql
+++ b/example/.output.graphql
@@ -1,5 +1,3 @@
-
-                mutation Output($result: FunctionResult!) {
-                    handleResult(result: $result)
-                }
-            
+mutation Output($result: FunctionResult!) {
+    handleResult(result: $result)
+}


### PR DESCRIPTION
#gsd:34464
Part of https://github.com/Shopify/script-service/issues/6917

Will make it easier to generate output query file contents to support different function target result types

### Example

#### `schema.graphql`

```graphql
"""
The root mutation for the API.
"""
type MutationRoot {
  """
  Handles the function result for the fetch target.
  """
  fetch(result: FunctionFetchResult!): Void!

  """
  Handles the function result for the validate target.
  """
  validate(result: FunctionValidateResult!): Void!
}
```

#### `.fetch.output.graphql`

```graphql
mutation Output($result: FunctionFetchResult!) {
    fetch(result: $result)
}
```

#### `.validate.output.graphql`

```graphql
mutation Output($result: FunctionValidateResult!) {
    validate(result: $result)
}
```