### PR TITLE
Bump version to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "graphql_client",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_macro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "convert_case",
  "proc-macro2",

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-shopify_function = { path = "../shopify_function", version = "0.3.0" }
+shopify_function = { path = "../shopify_function", version = "0.4.0" }
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
 graphql_client = "0.13.0"

--- a/example_with_targets/Cargo.toml
+++ b/example_with_targets/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-shopify_function = { path = "../shopify_function", version = "0.3.0" }
+shopify_function = { path = "../shopify_function", version = "0.4.0" }
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
 graphql_client = "0.13.0"

--- a/shopify_function/Cargo.toml
+++ b/shopify_function/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Surma <surma@shopify.com>", "Delta Pham <d.pham@shopify.com>"]
 license = "MIT"
@@ -10,7 +10,7 @@ description = "Crate to write Shopify Functions in Rust."
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.62"
-shopify_function_macro = { version = "0.3.0", path = "../shopify_function_macro" }
+shopify_function_macro = { version = "0.4.0", path = "../shopify_function_macro" }
 
 [dev-dependencies]
 graphql_client = "0.13.0"

--- a/shopify_function_macro/Cargo.toml
+++ b/shopify_function_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_macro"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Surma <surma@shopify.com>", "Delta Pham <d.pham@shopify.com>"]
 license = "MIT"


### PR DESCRIPTION
# Version 0.4.0

# Changes

efc0d57 Change shortId to handle
e8bb42e Note export default
991831f Tweak export definition
312ee77 Introduce `Decimal` helper type
738b202 Add ShortID to Scalars
573992a Export in toml is required for multiple targets
277a61f Fix copypasta example_with_targets README.md
b731209 Replace arg parse panic! with lookahead.error()
a0e9d48 Derive Serialize on generated types
326b55d Update README for example_with_targets
d9e933c export -> target arg
e6b36af Add overridable module name arg
6caf7f8 Export original function
22872b3 Use error result for compiler errors
c665f3c Minor updates
6296a95 Remove output type param
1253c6f Add example with targets