### PR TITLE
Decimal implements Deref

### DIFF
--- a/shopify_function/src/scalars/decimal.rs
+++ b/shopify_function/src/scalars/decimal.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{ops::Deref, str::FromStr};
 
 /// Convenience wrapper for converting between Shopify's `Decimal` scalar, which
 /// is serialized as a `String`, and Rust's `f64`.
@@ -12,6 +12,14 @@ impl Decimal {
     /// Access the value as an `f64`
     pub fn as_f64(&self) -> f64 {
         self.0
+    }
+}
+
+impl Deref for Decimal {
+    type Target = f64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 


### PR DESCRIPTION
This PR implements `Deref` for Decimal, to remove the need to write `.as_f64`/`.0` to access the inner value and its functions. 

The original PR for decimals mentions (https://github.com/Shopify/shopify-function-rust/pull/34#issuecomment-1647986477) not implementing it based on rust docs guidance. At the moment, the rust community is still trying to define what a smart pointer is (https://github.com/rust-lang/rust/issues/91004). 

In my use case, I commonly just need to just work with the inner value of Decimal, without really caring about the wrapper, which results in a lot of .0 or .as_f64. I'd figure other developers might be in the same boat. I do not see any real downside with implementing `Deref` in this instance.

 