### PR TITLE
Add date and time scalars

### DIFF
--- a/shopify_function/src/scalars.rs
+++ b/shopify_function/src/scalars.rs
@@ -8,3 +8,8 @@ pub use decimal::Decimal;
 pub type Void = ();
 pub type URL = String;
 pub type Handle = String;
+
+pub type Date = String;
+pub type DateTime = String;
+pub type DateTimeWithoutTimezone = String;
+pub type TimeWithoutTimezone = String;

--- a/shopify_function_macro/src/lib.rs
+++ b/shopify_function_macro/src/lib.rs
@@ -168,10 +168,16 @@ fn extract_shopify_function_return_type(ast: &syn::ItemFn) -> Result<&syn::Ident
     use syn::*;
 
     let ReturnType::Type(_arrow, ty) = &ast.sig.output else {
-        return Err(Error::new_spanned(&ast.sig, "Shopify Functions require an explicit return type"))
+        return Err(Error::new_spanned(
+            &ast.sig,
+            "Shopify Functions require an explicit return type",
+        ));
     };
     let Type::Path(path) = ty.as_ref() else {
-        return Err(Error::new_spanned(&ast.sig, "Shopify Functions must return a Result"))
+        return Err(Error::new_spanned(
+            &ast.sig,
+            "Shopify Functions must return a Result",
+        ));
     };
     let result = path.path.segments.last().unwrap();
     if result.ident != "Result" {
@@ -181,7 +187,10 @@ fn extract_shopify_function_return_type(ast: &syn::ItemFn) -> Result<&syn::Ident
         ));
     }
     let PathArguments::AngleBracketed(generics) = &result.arguments else {
-        return Err(Error::new_spanned(result, "Shopify Function Result is missing generic arguments"))
+        return Err(Error::new_spanned(
+            result,
+            "Shopify Function Result is missing generic arguments",
+        ));
     };
     if generics.args.len() != 1 {
         return Err(Error::new_spanned(
@@ -190,10 +199,16 @@ fn extract_shopify_function_return_type(ast: &syn::ItemFn) -> Result<&syn::Ident
         ));
     }
     let GenericArgument::Type(ty) = generics.args.first().unwrap() else {
-        return Err(Error::new_spanned(generics, "Shopify Function Result expects a type"))
+        return Err(Error::new_spanned(
+            generics,
+            "Shopify Function Result expects a type",
+        ));
     };
     let Type::Path(path) = ty else {
-        return Err(Error::new_spanned(result, "Unexpected result type for Shopify Function Result"))
+        return Err(Error::new_spanned(
+            result,
+            "Unexpected result type for Shopify Function Result",
+        ));
     };
     Ok(&path.path.segments.last().as_ref().unwrap().ident)
 }


### PR DESCRIPTION
Part of https://github.com/Shopify/script-service/issues/7594

```graphql
"""
Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date string.
For example, September 7, 2019 is represented as `"2019-07-16"`.
"""
scalar Date

"""
Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date and time string.
For example, 3:50 pm on September 7, 2019 in the time zone of UTC (Coordinated Universal Time) is
represented as `"2019-09-07T15:50:00Z`".
"""
scalar DateTime

"""
A subset of the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format that
includes the date and time but not the timezone which is determined from context.

For example, "2018-01-01T00:00:00".
"""
scalar DateTimeWithoutTimezone

"""
A subset of the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format that
includes the time but not the date or timezone which is determined from context.
For example, "05:43:21".
"""
scalar TimeWithoutTimezone
```

```diff
d@Delta-Shopify delivery-customization % cargo b
   Compiling shopify_function_macro v0.5.0 (/Users/d/src/github.com/Shopify/shopify-function-rust/shopify_function_macro)
   Compiling shopify_function v0.5.0 (/Users/d/src/github.com/Shopify/shopify-function-rust/shopify_function)
   Compiling delivery-customization v1.0.0 (/Users/d/apps/nov-29/extensions/delivery-customization)
-error[E0412]: cannot find type `Date` in module `super`
-  --> src/run.rs:16:1
-   |
-16 | #[shopify_function_target(query_path = "src/run.graphql", schema_path = "schema.graphql")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `super`
-   |
-   = note: this error originates in the derive macro `graphql_client::GraphQLQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-For more information about this error, try `rustc --explain E0412`.
-error: could not compile `delivery-customization` (bin "delivery-customization") due to previous error
+    Finished dev [unoptimized + debuginfo] target(s) in 1.04s
```

Unrelated lint fixes in `shopify_function_macro/src/lib.rs`:

```sh
rustup update stable
```

```sh
cargo fmt
```