### PR TITLE
Release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "graphql_client",
  "serde",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "convert_case",
  "proc-macro2",

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-shopify_function = { path = "../shopify_function", version = "0.5.0" }
+shopify_function = { path = "../shopify_function" }
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
 graphql_client = "0.13.0"

--- a/example_with_targets/Cargo.toml
+++ b/example_with_targets/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-shopify_function = { path = "../shopify_function", version = "0.5.0" }
+shopify_function = { path = "../shopify_function" }
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
 graphql_client = "0.13.0"

--- a/shopify_function/Cargo.toml
+++ b/shopify_function/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT"
 description = "Crate to write Shopify Functions in Rust."
 
 [dependencies]
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
 shopify_function_macro = { version = "0.5.0", path = "../shopify_function_macro" }
+serde = { version = "1.0.13", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 graphql_client = "0.13.0"

--- a/shopify_function/Cargo.toml
+++ b/shopify_function/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "shopify_function"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Surma <surma@shopify.com>", "Delta Pham <d.pham@shopify.com>"]
 license = "MIT"
 description = "Crate to write Shopify Functions in Rust."
 
 [dependencies]
-shopify_function_macro = { version = "0.5.0", path = "../shopify_function_macro" }
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
+shopify_function_macro = { version = "0.6.0", path = "../shopify_function_macro" }
 
 [dev-dependencies]
 graphql_client = "0.13.0"

--- a/shopify_function_macro/Cargo.toml
+++ b/shopify_function_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_macro"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Surma <surma@shopify.com>", "Delta Pham <d.pham@shopify.com>"]
 license = "MIT"


### PR DESCRIPTION
Bump the crates' version to v0.6.0.

Also reverts 66584fd's serde & serde_json bump; while users should be encouraged to use the latest version, there's no requirement on our end. I don't think that change was necessary nor useful, on second thought.