### PR TITLE
Use Ryū's small feature to cut ~9kb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "combine"
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "example"
@@ -140,9 +140,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "proc-macro2"
@@ -204,6 +204,7 @@ name = "shopify_function"
 version = "0.6.0"
 dependencies = [
  "graphql_client",
+ "ryu",
  "serde",
  "serde_json",
  "shopify_function_macro",

--- a/shopify_function/Cargo.toml
+++ b/shopify_function/Cargo.toml
@@ -11,5 +11,11 @@ serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
 shopify_function_macro = { version = "0.6.0", path = "../shopify_function_macro" }
 
+# Use the `small` feature of ryu (transitive dependency through serde_json)
+# to shave off ~9kb of the Wasm binary size.
+[dependencies.ryu]
+version = "*"
+features = ["small"]
+
 [dev-dependencies]
 graphql_client = "0.13.0"


### PR DESCRIPTION
The ryu crate is used by serde_json to format floats when JSON encoding and when printing floats on JSON parse errors. The `small` feature reduces its binary size (it embeds a smaller table) at the cost of some performance. This change makes it so the "small" feature is used for Functions using this crate, shaving ~9kb.

Given dumping floats probably isn't the most frequent operation, and that the difference in performance is minimal (see below), this seems reasonable.

The caveat is that it doesn't look users can opt-in using the default features (i.e. `[]`) of ryu, or at least, I couldn't figure out how. If we think this is problematic, we could update `function-examples`' `Cargo.toml`s to include the feature override.


<details><summary>The benchmark</summary>
<p>

```
$ cargo bench
running 16 tests
test bench_ryu::bench_0_f32         ... bench:           1 ns/iter (+/- 0)
test bench_ryu::bench_0_f64         ... bench:           1 ns/iter (+/- 0)
test bench_ryu::bench_e_f32         ... bench:          10 ns/iter (+/- 0)
test bench_ryu::bench_e_f64         ... bench:          15 ns/iter (+/- 7)
test bench_ryu::bench_max_f32       ... bench:          10 ns/iter (+/- 1)
test bench_ryu::bench_max_f64       ... bench:          22 ns/iter (+/- 1)
test bench_ryu::bench_short_f32     ... bench:          13 ns/iter (+/- 1)
test bench_ryu::bench_short_f64     ... bench:          26 ns/iter (+/- 1)
test bench_std_fmt::bench_0_f32     ... bench:          11 ns/iter (+/- 0)
test bench_std_fmt::bench_0_f64     ... bench:          11 ns/iter (+/- 0)
test bench_std_fmt::bench_e_f32     ... bench:          52 ns/iter (+/- 2)
test bench_std_fmt::bench_e_f64     ... bench:          58 ns/iter (+/- 0)
test bench_std_fmt::bench_max_f32   ... bench:          50 ns/iter (+/- 0)
test bench_std_fmt::bench_max_f64   ... bench:          74 ns/iter (+/- 4)
test bench_std_fmt::bench_short_f32 ... bench:          42 ns/iter (+/- 2)
test bench_std_fmt::bench_short_f64 ... bench:          41 ns/iter (+/- 0)

$ cargo bench --features small
running 16 tests
test bench_ryu::bench_0_f32         ... bench:           1 ns/iter (+/- 0)
test bench_ryu::bench_0_f64         ... bench:           1 ns/iter (+/- 0)
test bench_ryu::bench_e_f32         ... bench:          20 ns/iter (+/- 1)
test bench_ryu::bench_e_f64         ... bench:          20 ns/iter (+/- 1)
test bench_ryu::bench_max_f32       ... bench:          20 ns/iter (+/- 0)
test bench_ryu::bench_max_f64       ... bench:          20 ns/iter (+/- 2)
test bench_ryu::bench_short_f32     ... bench:          22 ns/iter (+/- 0)
test bench_ryu::bench_short_f64     ... bench:          31 ns/iter (+/- 2)
test bench_std_fmt::bench_0_f32     ... bench:          11 ns/iter (+/- 0)
test bench_std_fmt::bench_0_f64     ... bench:          11 ns/iter (+/- 0)
test bench_std_fmt::bench_e_f32     ... bench:          50 ns/iter (+/- 1)
test bench_std_fmt::bench_e_f64     ... bench:          55 ns/iter (+/- 3)
test bench_std_fmt::bench_max_f32   ... bench:          48 ns/iter (+/- 1)
test bench_std_fmt::bench_max_f64   ... bench:          74 ns/iter (+/- 0)
test bench_std_fmt::bench_short_f32 ... bench:          41 ns/iter (+/- 0)
test bench_std_fmt::bench_short_f64 ... bench:          40 ns/iter (+/- 0)
```

</p>
</details> 