### PR TITLE
Make codegen'd mods public

### DIFF
--- a/example_with_targets/src/tests.rs
+++ b/example_with_targets/src/tests.rs
@@ -3,39 +3,36 @@ use shopify_function::{run_function_with_input, Result};
 
 #[test]
 fn test_a() -> Result<()> {
-    let result = serde_json::to_string(
-        &run_function_with_input(
-            target_a,
-            r#"
+    let result = run_function_with_input(
+        target_a,
+        r#"
             {
                 "id": "gid://shopify/Order/1234567890",
                 "num": 123,
                 "name": "test"
             }
         "#,
-        )
-        .unwrap(),
     )?;
-    let expected = r#"{"status":200}"#;
+    let expected = crate::target_a::output::FunctionTargetAResult { status: Some(200) };
     assert_eq!(result, expected);
     Ok(())
 }
 
 #[test]
 fn test_function_b() -> Result<()> {
-    let result = serde_json::to_string(
-        &run_function_with_input(
-            function_b,
-            r#"
+    let result = run_function_with_input(
+        function_b,
+        r#"
             {
                 "id": "gid://shopify/Order/1234567890",
                 "aResult": 200
             }
         "#,
-        )
-        .unwrap(),
     )?;
-    let expected = r#"{"name":"new name: \"gid://shopify/Order/1234567890\""}"#;
+    let expected = crate::mod_b::output::FunctionTargetBResult {
+        name: Some("new name: \"gid://shopify/Order/1234567890\"".to_string()),
+    };
+
     assert_eq!(result, expected);
     Ok(())
 }

--- a/shopify_function_macro/src/lib.rs
+++ b/shopify_function_macro/src/lib.rs
@@ -7,8 +7,9 @@ use std::path::Path;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
-    self, parse::Parse, parse::ParseStream, parse_macro_input, Expr, ExprArray, FnArg, LitStr,
-    Token,
+    self,
+    parse::{Parse, ParseStream},
+    parse_macro_input, Expr, ExprArray, FnArg, LitStr, Token,
 };
 
 #[derive(Clone, Default)]
@@ -461,6 +462,12 @@ fn graphql_codegen_options(
     options.set_response_derives("Clone,Debug,PartialEq,Deserialize,Serialize".to_string());
     options.set_variables_derives("Clone,Debug,PartialEq,Deserialize".to_string());
     options.set_skip_serializing_none(true);
+    options.set_module_visibility(
+        syn::VisPublic {
+            pub_token: <Token![pub]>::default(),
+        }
+        .into(),
+    );
     if let Some(extern_enums) = extern_enums {
         options.set_extern_enums(extern_enums.to_vec());
     }


### PR DESCRIPTION
I can't think of a good reasons for these mods to be private given the nature of Shopify Functions. By keeping them public, testing will be easier and we'll avoid a breaking change.

Fixes #60