### PR TITLE
Use `ryu` to serialize `Decimal`

### DIFF
--- a/shopify_function/src/scalars/decimal.rs
+++ b/shopify_function/src/scalars/decimal.rs
@@ -33,7 +33,7 @@ impl TryFrom<String> for Decimal {
 
 impl From<Decimal> for String {
     fn from(value: Decimal) -> Self {
-        value.0.to_string()
+        ryu::Buffer::new().format(value.0).to_string()
     }
 }
 


### PR DESCRIPTION
`ryu` is used by `serde_json`, so we are already including the `f64` serialization logic in our binaries. Replacing the `Decimal` implementation of `Into<String>` to make use of `ryu` means that we can save ~20KB in binary size.

The example on `main`: 165KB
The example on this branch: 142KB