### PR TITLE
Revive default extern enums for outputs

### DIFF
--- a/shopify_function/tests/fixtures/schema.graphql
+++ b/shopify_function/tests/fixtures/schema.graphql
@@ -51,6 +51,7 @@ The result of the function.
 """
 input FunctionResult {
   name: String
+  country: CountryCode
 }
 
 enum CountryCode {

--- a/shopify_function/tests/fixtures/schema_with_targets.graphql
+++ b/shopify_function/tests/fixtures/schema_with_targets.graphql
@@ -69,6 +69,7 @@ The result of API target B.
 """
 input FunctionTargetBResult {
   name: String
+  country: CountryCode
 }
 
 enum CountryCode {

--- a/shopify_function/tests/shopify_function.rs
+++ b/shopify_function/tests/shopify_function.rs
@@ -16,7 +16,7 @@ generate_types!(
 
 #[test]
 fn test_function() {
-    let expected_result = r#"{"name":"new name: gid://shopify/Order/1234567890"}"#;
+    let expected_result = r#"{"name":"new name: gid://shopify/Order/1234567890","country":"CA"}"#;
     main().unwrap();
     let actual_result = std::str::from_utf8(unsafe { FUNCTION_OUTPUT.as_slice() }).unwrap();
     assert_eq!(actual_result, expected_result);
@@ -29,5 +29,6 @@ fn test_function() {
 fn my_function(input: input::ResponseData) -> Result<output::FunctionResult> {
     Ok(output::FunctionResult {
         name: Some(format!("new name: {}", input.id)),
+        country: Some("CA".to_string()),
     })
 }

--- a/shopify_function/tests/shopify_function_target.rs
+++ b/shopify_function/tests/shopify_function_target.rs
@@ -41,7 +41,7 @@ static mut TARGET_B_OUTPUT: Vec<u8> = vec![];
 
 #[test]
 fn test_mod_b_export() {
-    let expected_result = r#"{"name":"new name: gid://shopify/Order/1234567890"}"#;
+    let expected_result = r#"{"name":"new name: gid://shopify/Order/1234567890","country":"CA"}"#;
     mod_b::export();
     let actual_result = std::str::from_utf8(unsafe { TARGET_B_OUTPUT.as_slice() }).unwrap();
     assert_eq!(actual_result, expected_result);
@@ -60,6 +60,7 @@ fn some_function(
 ) -> Result<mod_b::output::FunctionTargetBResult> {
     Ok(mod_b::output::FunctionTargetBResult {
         name: Some(format!("new name: {}", input.id)),
+        country: Some("CA".to_string()),
     })
 }
 


### PR DESCRIPTION
Default `extern_enums` for output got lost when we merged #51. This PR brings them back.