### PR TITLE
v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "graphql_client",
  "graphql_client_codegen",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_macro"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "convert_case",
  "graphql_client_codegen",

--- a/shopify_function/Cargo.toml
+++ b/shopify_function/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 authors = ["Surma <surma@shopify.com>", "Delta Pham <d.pham@shopify.com>"]
 license = "MIT"
@@ -9,7 +9,7 @@ description = "Crate to write Shopify Functions in Rust."
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function_macro = { version = "0.7.1", path = "../shopify_function_macro" }
+shopify_function_macro = { version = "0.8.0", path = "../shopify_function_macro" }
 
 # Use the `small` feature of ryu (transitive dependency through serde_json)
 # to shave off ~9kb of the Wasm binary size.

--- a/shopify_function_macro/Cargo.toml
+++ b/shopify_function_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function_macro"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 authors = ["Surma <surma@shopify.com>", "Delta Pham <d.pham@shopify.com>"]
 license = "MIT"


### PR DESCRIPTION
Bumping to `0.8.0` because we rely on a different version of `graphql_client` as a result of #51 (this was an oversight in #65) 