### PR TITLE
Map JSON scalar to serde_json::Value

### DIFF
--- a/shopify_function/src/scalars.rs
+++ b/shopify_function/src/scalars.rs
@@ -4,6 +4,7 @@ pub type Boolean = bool;
 pub type Float = f64;
 pub type Int = i64;
 pub type ID = String;
+pub type JSON = serde_json::Value;
 pub use decimal::Decimal;
 pub type Void = ();
 pub type URL = String;


### PR DESCRIPTION
This PR allows Rust Functions to use the new `MetaField.jsonValue` field, of type `JSON!`:

https://shopify.dev/changelog/new-metafield-jsonvalue-field

Without this, you get the following errors from `cargo`:

```
error[E0412]: cannot find type `JSON` in module `super`
  --> PATH_TO_FUNCTION_FILE.rs:7:1
   |
7  | / generate_types!(
8  | |     query_path = "PATH_TO_INPUT_QUERY.graphql",
9  | |     schema_path = "PATH_TO_SCHEMA.graphql"
10 | | );
   | |_^ not found in `super`
   |
note: type alias `crate::input::JSON` exists but is inaccessible
  --> PATH_TO_FUNCTION_FILE.rs:28:1
   |
28 | / generate_types!(
29 | |     query_path = "PATH_TO_INPUT_QUERY.graphql",
30 | |     schema_path = "PATH_TO_SCHEMA.graphql"
31 | | );
   | |_^ not accessible
   = note: this error originates in the derive macro `graphql_client::GraphQLQuery` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0369]: binary operation `==` cannot be applied to type `std::option::Option<input::InputDiscountNodeMetafield>`
  --> PATH_TO_FUNCTION_FILE.rs:7:1
   |
7  | / generate_types!(
8  | |     query_path = "PATH_TO_INPUT_QUERY.graphql",
9  | |     schema_path = "PATH_TO_SCHEMA.graphql"
10 | | );
   | |_^
   |
   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
```