### PR TITLE
Bump shopify_function crate to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "graphql_client",
  "graphql_client_codegen",

--- a/shopify_function/Cargo.toml
+++ b/shopify_function/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shopify_function"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Surma <surma@shopify.com>", "Delta Pham <d.pham@shopify.com>"]
 license = "MIT"


### PR DESCRIPTION
This PR bumps the `shopify_function` crate to 0.8.1.

The [changes](https://github.com/Shopify/shopify-function-rust/compare/v0.8.0...main) are primarily Dependabot updates + adding JSON scalar support.