### PR TITLE
Add reviewers for github actions dependabots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    reviewers:
+      - "@Shopify/functions-dependabot-reviewers"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:


### PR DESCRIPTION
Added in #127, we should auto-assign reviewers for these dependabots