### PR TITLE
Add `Deserialize` implementations for input objects

### DIFF
--- a/example_with_targets/schema.graphql
+++ b/example_with_targets/schema.graphql
@@ -9,6 +9,11 @@ Only allow the field to be queried when targeting one of the specified targets.
 directive @restrictTarget(only: [String!]!) on FIELD_DEFINITION
 
 """
+Requires that exactly one field must be supplied and that field must not be `null`.
+"""
+directive @oneOf on INPUT_OBJECT
+
+"""
 Represents an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-encoded date string.
 For example, September 7, 2019 is represented as `"2019-07-16"`.
 """
@@ -108,6 +113,20 @@ The result of API target B.
 """
 input FunctionTargetBResult {
   name: String
+  operations: [Operation!]!
+}
+
+input Operation @oneOf {
+  doThis: This
+  doThat: That
+}
+
+input This {
+  thisField: String!
+}
+
+input That {
+  thatField: Int!
 }
 
 """

--- a/example_with_targets/src/main.rs
+++ b/example_with_targets/src/main.rs
@@ -23,6 +23,12 @@ fn target_a(_input: schema::target_a::Input) -> Result<schema::FunctionTargetARe
 fn target_b(input: schema::target_b::Input) -> Result<schema::FunctionTargetBResult> {
     Ok(schema::FunctionTargetBResult {
         name: Some(format!("new name: \"{}\"", input.id())),
+        operations: vec![
+            schema::Operation::DoThis(schema::This {
+                this_field: "this field".to_string(),
+            }),
+            schema::Operation::DoThat(schema::That { that_field: 42 }),
+        ],
     })
 }
 

--- a/example_with_targets/src/tests.rs
+++ b/example_with_targets/src/tests.rs
@@ -31,6 +31,12 @@ fn test_target_b() -> Result<()> {
     )?;
     let expected = crate::schema::FunctionTargetBResult {
         name: Some("new name: \"gid://shopify/Order/1234567890\"".to_string()),
+        operations: vec![
+            crate::schema::Operation::DoThis(crate::schema::This {
+                this_field: "this field".to_string(),
+            }),
+            crate::schema::Operation::DoThat(crate::schema::That { that_field: 42 }),
+        ],
     };
 
     assert_eq!(result, expected);

--- a/integration_tests/tests/integration_test.rs
+++ b/integration_tests/tests/integration_test.rs
@@ -39,7 +39,19 @@ fn test_example_with_targets_target_b() -> Result<()> {
     assert_eq!(
         output,
         serde_json::json!({
-            "name": "new name: \"gid://shopify/Order/1234567890\""
+            "name": "new name: \"gid://shopify/Order/1234567890\"",
+            "operations": [
+                {
+                    "doThis": {
+                        "thisField": "this field"
+                    }
+                },
+                {
+                    "doThat": {
+                        "thatField": 42
+                    }
+                }
+            ]
         })
     );
     Ok(())


### PR DESCRIPTION
There are some cases where Functions may want to deserialize these types from the `jsonBody` of a fetch result