### PR TITLE
Bump `shopify_function_wasm_api` to `0.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,11 +1253,12 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_wasm_api"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57a2e64ef7d28cbe26bf591fd084093327d9d359e38355010720d818cd92ba9"
+checksum = "cb7952650d134210fcd92b56a6cdc666a4ed5d0c56a8a21bf9113b62dee52d27"
 dependencies = [
  "rmp-serde",
+ "seq-macro",
  "serde_json",
  "shopify_function_provider",
  "shopify_function_wasm_api_core",

--- a/shopify_function/Cargo.toml
+++ b/shopify_function/Cargo.toml
@@ -9,7 +9,7 @@ description = "Crate to write Shopify Functions in Rust."
 [dependencies]
 serde_json = "1.0"
 shopify_function_macro = { version = "1.1.0", path = "../shopify_function_macro" }
-shopify_function_wasm_api = "0.1.0"
+shopify_function_wasm_api = "0.2.0"
 
 # Use the `small` feature of ryu (transitive dependency through serde_json)
 # to shave off ~9kb of the Wasm binary size.


### PR DESCRIPTION
Includes bug fix for intermittent test failures, and some additional `Deserialize` implementations