### PR TITLE
Remove unused code in example

### DIFF
--- a/example_with_targets/src/main.rs
+++ b/example_with_targets/src/main.rs
@@ -1,10 +1,6 @@
 use shopify_function::prelude::*;
 use shopify_function::Result;
 
-#[derive(Deserialize)]
-#[shopify_function(rename_all = "camelCase")]
-struct Configuration {}
-
 #[typegen("./schema.graphql", enums_as_str = ["CountryCode"])]
 mod schema {
     #[query("./a.graphql")]


### PR DESCRIPTION
Seems to be a new lint rule in the latest version of Rust that is causing CI failures on main... are we okay with removing this dead code from the example or would we rather update the example to use it?