### PR TITLE
Bump version to v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shopify_function"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "ryu",
  "serde_json",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "shopify_function_macro"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "bluejay-core",
  "bluejay-typegen-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ members = [
 ]
 
 [workspace.package]
-version = "2.1.0"
+version = "2.2.0"
 
 [workspace.dependencies]
-shopify_function_macro = { version = "=2.1.0", path = "shopify_function_macro" }
+shopify_function_macro = { version = "=2.2.0", path = "shopify_function_macro" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Bumps `shopify_function` and `shopify_function_macro` to v2.2.0 for rollout of #227.

Validation:
- `cargo check`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`